### PR TITLE
Enable CORS Headers

### DIFF
--- a/R/middleware.R
+++ b/R/middleware.R
@@ -357,6 +357,10 @@ HandlerManager <- R6Class("HandlerManager",
         if (inherits(response, "httpResponse")) {
           headers <- as.list(response$headers)
           headers$'Content-Type' <- response$content_type
+          if(Sys.getenv("ALLOW_ORIGIN") != "") {
+            origin <- Sys.getenv("ALLOW_ORIGIN")
+            headers$'Access-Control-Allow-Origin' <- origin
+          }
 
           response <- filter(req, response)
           if (head_request) {


### PR DESCRIPTION
Currently set via environment variables.  Maybe a little sketchy, but also unobtrusive.